### PR TITLE
Precompile deface

### DIFF
--- a/app/views/add_on/deploys/capistrano.html.erb
+++ b/app/views/add_on/deploys/capistrano.html.erb
@@ -55,6 +55,13 @@ namespace :deploy do
   end
 end
 
+namespace :deface do
+  task :precompile do
+    # the spree app conditionally disables deface in production based on DEFACE_PRECOMPILE
+    run "cd #{release_path} && #{rake} RAILS_ENV=#{rails_env} DEFACE_PRECOMPILE=true deface:precompile" 
+  end
+end
+
 <% if @compile_assets %>
 before 'deploy:assets:precompile', 'deploy:symlink_shared'
 <% else %>


### PR DESCRIPTION
I've added a precomile task to the generated capistrano recipe. 

Questions:

-  Should we make precompiling deface default ? are there any downsides to precompiling deface in production ?

-  Should we add an option to the UI for it ?

-  Should we add the conditional enabling/disabling of deface based on pre-compilation @iloveitaly proposed ?